### PR TITLE
Get Started / Onboarding Page

### DIFF
--- a/PlateUp/app.json
+++ b/PlateUp/app.json
@@ -8,7 +8,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
-      "image": "./assets/splash.png",
       "resizeMode": "cover",
       "backgroundColor": "#ffffff"
     },

--- a/PlateUp/constants/Theme.js
+++ b/PlateUp/constants/Theme.js
@@ -8,18 +8,17 @@ export default {
     ERROR: "#F5365C",
     SUCCESS: "#2DCE89",
     WARNING: "#FB6340",
-    /*not yet changed */
     MUTED: "#ADB5BD",
     INPUT: "#DCDCDC",
     INPUT_SUCCESS: "#7BDEB2",
     INPUT_ERROR: "#FCB3A4",
-    ACTIVE: "#5E72E4", //same as primary
+    ACTIVE: "#5E72E4",
     BUTTON_COLOR: "#9C26B0",
     PLACEHOLDER: "#9FA5AA",
     SWITCH_ON: "#5E72E4",
     SWITCH_OFF: "#D4D9DD",
-    GRADIENT_START: "#6B24AA",
-    GRADIENT_END: "#AC2688",
+    GRADIENT_START: "#EB5757",
+    GRADIENT_END: "#F2994A",
     PRICE_COLOR: "#EAD5FB",
     BORDER_COLOR: "#E7E7E7",
     BLOCK: "#E7E7E7",
@@ -28,5 +27,6 @@ export default {
     BORDER: "#CAD1D7",
     WHITE: "#FFFFFF",
     BLACK: "#000000",
+    BLUE: "#225AA6",
   },
 };

--- a/PlateUp/navigation/Screens.js
+++ b/PlateUp/navigation/Screens.js
@@ -38,10 +38,10 @@ function ElementsStack(props) {
           header: ({ navigation, scene }) => (
             <Header title="Elements" navigation={navigation} scene={scene} />
           ),
-          cardStyle: { backgroundColor: "#F8F9FE" }
+          cardStyle: { backgroundColor: "#F8F9FE" },
         }}
       />
-            <Stack.Screen
+      <Stack.Screen
         name="Pro"
         component={Pro}
         options={{
@@ -55,7 +55,7 @@ function ElementsStack(props) {
               scene={scene}
             />
           ),
-          headerTransparent: true
+          headerTransparent: true,
         }}
       />
     </Stack.Navigator>
@@ -72,10 +72,10 @@ function ArticlesStack(props) {
           header: ({ navigation, scene }) => (
             <Header title="Articles" navigation={navigation} scene={scene} />
           ),
-          cardStyle: { backgroundColor: "#F8F9FE" }
+          cardStyle: { backgroundColor: "#F8F9FE" },
         }}
       />
-            <Stack.Screen
+      <Stack.Screen
         name="Pro"
         component={Pro}
         options={{
@@ -89,7 +89,7 @@ function ArticlesStack(props) {
               scene={scene}
             />
           ),
-          headerTransparent: true
+          headerTransparent: true,
         }}
       />
     </Stack.Navigator>
@@ -113,10 +113,10 @@ function ProfileStack(props) {
             />
           ),
           cardStyle: { backgroundColor: "#FFFFFF" },
-          headerTransparent: true
+          headerTransparent: true,
         }}
       />
-            <Stack.Screen
+      <Stack.Screen
         name="Pro"
         component={Pro}
         options={{
@@ -130,7 +130,7 @@ function ProfileStack(props) {
               scene={scene}
             />
           ),
-          headerTransparent: true
+          headerTransparent: true,
         }}
       />
     </Stack.Navigator>
@@ -153,7 +153,7 @@ function HomeStack(props) {
               scene={scene}
             />
           ),
-          cardStyle: { backgroundColor: "#F8F9FE" }
+          cardStyle: { backgroundColor: "#F8F9FE" },
         }}
       />
       <Stack.Screen
@@ -170,7 +170,7 @@ function HomeStack(props) {
               scene={scene}
             />
           ),
-          headerTransparent: true
+          headerTransparent: true,
         }}
       />
     </Stack.Navigator>
@@ -184,10 +184,11 @@ export default function OnboardingStack(props) {
         name="Onboarding"
         component={Onboarding}
         option={{
-          headerTransparent: true
+          headerTransparent: true,
         }}
       />
       <Stack.Screen name="App" component={AppStack} />
+      <Stack.Screen name="Register" component={Register} />
     </Stack.Navigator>
   );
 }
@@ -196,10 +197,10 @@ function AppStack(props) {
   return (
     <Drawer.Navigator
       style={{ flex: 1 }}
-      drawerContent={props => <CustomDrawerContent {...props} />}
+      drawerContent={(props) => <CustomDrawerContent {...props} />}
       drawerStyle={{
         backgroundColor: "white",
-        width: width * 0.8
+        width: width * 0.8,
       }}
       drawerContentOptions={{
         activeTintcolor: "white",
@@ -213,22 +214,21 @@ function AppStack(props) {
           justifyContent: "center",
           alignContent: "center",
           alignItems: "center",
-          overflow: "hidden"
+          overflow: "hidden",
         },
         labelStyle: {
           fontSize: 18,
           marginLeft: 12,
-          fontWeight: "normal"
-        }
+          fontWeight: "normal",
+        },
       }}
       initialRouteName="Home"
     >
       <Drawer.Screen name="Home" component={HomeStack} />
       <Drawer.Screen name="Profile" component={ProfileStack} />
-      <Drawer.Screen name="Account" component={Register} />
+      <Drawer.Screen name="Register" component={Register} />
       <Drawer.Screen name="Elements" component={ElementsStack} />
       <Drawer.Screen name="Articles" component={ArticlesStack} />
     </Drawer.Navigator>
   );
 }
-

--- a/PlateUp/navigation/Screens.js
+++ b/PlateUp/navigation/Screens.js
@@ -188,7 +188,7 @@ export default function OnboardingStack(props) {
         }}
       />
       <Stack.Screen name="App" component={AppStack} />
-      <Stack.Screen name="Register" component={Register} />
+      <Stack.Screen name="Registration" component={Register} />
     </Stack.Navigator>
   );
 }
@@ -226,7 +226,7 @@ function AppStack(props) {
     >
       <Drawer.Screen name="Home" component={HomeStack} />
       <Drawer.Screen name="Profile" component={ProfileStack} />
-      <Drawer.Screen name="Register" component={Register} />
+      <Drawer.Screen name="Registration" component={Register} />
       <Drawer.Screen name="Elements" component={ElementsStack} />
       <Drawer.Screen name="Articles" component={ArticlesStack} />
     </Drawer.Navigator>

--- a/PlateUp/screens/Onboarding.js
+++ b/PlateUp/screens/Onboarding.js
@@ -23,7 +23,7 @@ class Onboarding extends React.Component {
           <Button
             style={styles.button}
             color={argonTheme.COLORS.SECONDARY}
-            onPress={() => navigation.navigate("Register")}
+            onPress={() => navigation.navigate("Registration")}
             textStyle={{ color: argonTheme.COLORS.BLACK }}
           >
             Get Started

--- a/PlateUp/screens/Onboarding.js
+++ b/PlateUp/screens/Onboarding.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { Image, StyleSheet, StatusBar, Dimensions, Text } from "react-native";
-import { Block, Button, theme } from "galio-framework";
+import { Image, StyleSheet, StatusBar, Dimensions } from "react-native";
+import { Block, Button, Text, theme } from "galio-framework";
 import { LinearGradient } from "expo-linear-gradient";
 
 const { width, height } = Dimensions.get("screen");
@@ -13,13 +13,19 @@ class Onboarding extends React.Component {
     const { navigation } = this.props;
 
     return (
-      <LinearGradient style={styles.container} colors={["#EB5757", "#F2994A"]}>
+      <LinearGradient
+        style={styles.container}
+        colors={[
+          argonTheme.COLORS.GRADIENT_START,
+          argonTheme.COLORS.GRADIENT_END,
+        ]}
+      >
         <StatusBar hidden />
-        <Block style={styles.logoContainer}>
+        <Block center style={styles.logoContainer}>
           <Image source={Images.PlateUpLogo} style={styles.logoImage} />
           <Image source={Images.PlateUpName} style={styles.nameImage} />
         </Block>
-        <Block style={styles.inputContainer}>
+        <Block center style={styles.inputContainer}>
           <Button
             style={styles.button}
             color={argonTheme.COLORS.SECONDARY}
@@ -29,13 +35,13 @@ class Onboarding extends React.Component {
             Get Started
           </Button>
           <Text style={styles.text}>
+            Already have an account?{" "}
             <Text
-              style={[styles.text, styles.bold]}
+              style={styles.bold}
               onPress={() => navigation.navigate("App")}
             >
-              Login instead{" "}
+              Login
             </Text>
-            if you have an account
           </Text>
         </Block>
       </LinearGradient>
@@ -45,7 +51,7 @@ class Onboarding extends React.Component {
 
 const styles = StyleSheet.create({
   bold: {
-    color: "#225AA6",
+    color: argonTheme.COLORS.BLUE,
     fontWeight: "bold",
   },
   button: {
@@ -60,7 +66,6 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   inputContainer: {
-    alignItems: "center",
     paddingHorizontal: theme.SIZES.BASE * 2,
     position: "relative",
     bottom: height * 0.06,
@@ -70,7 +75,6 @@ const styles = StyleSheet.create({
     height: width * 0.725 * (201 / 279),
   },
   logoContainer: {
-    alignItems: "center",
     position: "absolute",
     width: "100%",
     top: height * 0.2648,

--- a/PlateUp/screens/Onboarding.js
+++ b/PlateUp/screens/Onboarding.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Image, StyleSheet, StatusBar, Dimensions } from "react-native";
+import { Image, StyleSheet, StatusBar, Dimensions, Text } from "react-native";
 import { Block, Button, theme } from "galio-framework";
 import { LinearGradient } from "expo-linear-gradient";
 
@@ -15,21 +15,28 @@ class Onboarding extends React.Component {
     return (
       <LinearGradient style={styles.container} colors={["#EB5757", "#F2994A"]}>
         <StatusBar hidden />
-        <Block center style={styles.logoContainer}>
+        <Block style={styles.logoContainer}>
           <Image source={Images.PlateUpLogo} style={styles.logoImage} />
           <Image source={Images.PlateUpName} style={styles.nameImage} />
         </Block>
-        <Block style={styles.padded}>
-          <Block center>
-            <Button
-              style={styles.button}
-              color={argonTheme.COLORS.SECONDARY}
+        <Block style={styles.inputContainer}>
+          <Button
+            style={styles.button}
+            color={argonTheme.COLORS.SECONDARY}
+            onPress={() => navigation.navigate("Register")}
+            textStyle={{ color: argonTheme.COLORS.BLACK }}
+          >
+            Get Started
+          </Button>
+          <Text style={styles.text}>
+            <Text
+              style={[styles.text, styles.bold]}
               onPress={() => navigation.navigate("App")}
-              textStyle={{ color: argonTheme.COLORS.BLACK }}
             >
-              Get Started
-            </Button>
-          </Block>
+              Login instead{" "}
+            </Text>
+            if you have an account
+          </Text>
         </Block>
       </LinearGradient>
     );
@@ -37,21 +44,33 @@ class Onboarding extends React.Component {
 }
 
 const styles = StyleSheet.create({
+  bold: {
+    color: "#225AA6",
+    fontWeight: "bold",
+  },
   button: {
     width: width - theme.SIZES.BASE * 4,
     height: theme.SIZES.BASE * 3,
     shadowRadius: 0,
     shadowOpacity: 0,
+    marginBottom: height * 0.0185,
   },
   container: {
     flex: 1,
     justifyContent: "flex-end",
+  },
+  inputContainer: {
+    alignItems: "center",
+    paddingHorizontal: theme.SIZES.BASE * 2,
+    position: "relative",
+    bottom: height * 0.06,
   },
   logoImage: {
     width: width * 0.725,
     height: width * 0.725 * (201 / 279),
   },
   logoContainer: {
+    alignItems: "center",
     position: "absolute",
     width: "100%",
     top: height * 0.2648,
@@ -62,10 +81,9 @@ const styles = StyleSheet.create({
     width: width * 0.725,
     height: width * 0.725 * (43 / 272),
   },
-  padded: {
-    paddingHorizontal: theme.SIZES.BASE * 2,
-    position: "relative",
-    bottom: theme.SIZES.BASE,
+  text: {
+    fontSize: 14,
+    lineHeight: 19,
   },
 });
 


### PR DESCRIPTION
Corresponding Issue: #11 

#18 implemented most of this view. The remainder work includes adding the Login text at the bottom as well as small styling changes. I renamed the Navigator component for the Registration Page, previously called Account, to Registration. This broke the Account Drawer Tab navigation. The fix requires work outside the scope of this ticket. We are going to need to make a new screen for it anyways, or we may even not support that tab anymore. We can deal with that then. 

**Screenshots**:
![image](https://user-images.githubusercontent.com/42985270/95406599-c5dd9480-08e8-11eb-8351-47f199cdd5e1.png)

Get Started Button takes you to the following screen
![image](https://user-images.githubusercontent.com/42985270/95401912-7002ef80-08dc-11eb-8edf-446af4485f1c.png)

Login instead takes you to the following screen
![image](https://user-images.githubusercontent.com/42985270/95401932-7db87500-08dc-11eb-82c6-0390bf11b9ef.png)

Once we design a login screen, it will take you there instead.