### PR TITLE
Refactor code for browseRecipes and add extra test coverage

### DIFF
--- a/PlateUp-reactnative/constants/utils.test.js
+++ b/PlateUp-reactnative/constants/utils.test.js
@@ -1,6 +1,6 @@
 import { constructQueryParams } from "./utils";
 
-
+// Tests written by Pranav Patel
 describe('constructQueryParams', () => {
 
     test('returns a query string when parameters are specified', () => {

--- a/PlateUp-reactnative/redux/features/browse_recipes.js
+++ b/PlateUp-reactnative/redux/features/browse_recipes.js
@@ -19,26 +19,9 @@ const queryParamMapping = {
 };
 
 export const fetchBrowseRecipes = createAsyncThunk('browse_recipes/fetchBrowseRecipes', async (settings, { rejectWithValue }) => {
-  const filters = { ...settings.filterSettings };
-  const searchQuery = settings.searchQuery;
-  let params = {}
-
-  if (filters.activateFilters) {
-    params = { ...filters, search: searchQuery }
-
-    delete params.activateFilters;
-
-    params.maxCookTimeHour = params.maxCookTime ? Math.floor(Number(params.maxCookTime) / 60).toString() : '';
-    params.maxCookTimeMinutes = params.maxCookTime ? (Number(params.maxCookTime) % 60).toString() : '';
-
-    delete params.maxCookTime;
-  }
-  else {
-    params = { search: searchQuery }
-  }
-
+  const params = processSettingsIntoParams(settings);
   const queryParams = constructQueryParams(params, queryParamMapping);
-
+  
   try {
     const response = await axios({
       method: 'get',
@@ -46,7 +29,6 @@ export const fetchBrowseRecipes = createAsyncThunk('browse_recipes/fetchBrowseRe
       url: `${env.SERVER_URL}/recipe${queryParams}`,
       responseType: 'json'
     });
-
     return response.data;
   } catch (err) {
     return rejectWithValue(err.response.data);
@@ -72,5 +54,26 @@ const browseRecipesSlice = createSlice({
     }
   }
 });
+
+export const processSettingsIntoParams = (settings) => {
+  const filters = { ...settings.filterSettings };
+  const searchQuery = settings.searchQuery;
+  let params = {}
+
+  if (filters.activateFilters) {
+    params = { ...filters, search: searchQuery }
+
+    params.maxCookTimeHour = params.maxCookTime ? Math.floor(Number(params.maxCookTime) / 60).toString() : '';
+    params.maxCookTimeMinutes = params.maxCookTime ? (Number(params.maxCookTime) % 60).toString() : '';
+
+    delete params.activateFilters;
+    delete params.maxCookTime;
+  }
+  else {
+    params = { search: searchQuery }
+  }
+
+  return params;
+}
 
 export default browseRecipesSlice.reducer;

--- a/PlateUp-reactnative/redux/features/browse_recipes.test.js
+++ b/PlateUp-reactnative/redux/features/browse_recipes.test.js
@@ -1,0 +1,121 @@
+import { fetchBrowseRecipes, processSettingsIntoParams } from "./browse_recipes";
+import browseRecipesReducer from "./browse_recipes";
+
+// Tests written by Pranav Patel
+describe('processSettingsIntoParams', () => {
+    test('correctly handles cooking details', () => {
+        const settings = {
+            filterSettings: {
+                activateFilters: true,
+                maxCookTime: "120",
+                maxCost: ""
+            },
+            searchQuery: ""
+        }
+
+        expect(processSettingsIntoParams(settings)).toEqual({
+            maxCost: "",
+            maxCookTimeHour: "2",
+            maxCookTimeMinutes: "0",
+            search: ""
+        })
+    });
+
+    test('correctly handles search query and max cost', () => {
+        const settings = {
+            filterSettings: {
+                activateFilters: true,
+                maxCookTime: "",
+                maxCost: "10",
+            },
+            searchQuery: "test"
+        }
+
+        expect(processSettingsIntoParams(settings)).toEqual({
+            maxCost: "10",
+            maxCookTimeHour: "",
+            maxCookTimeMinutes: "",
+            search: "test"
+        })
+    });
+
+    test('ignores filters when activateFilters is false', () => {
+        const settings = {
+            filterSettings: {
+                activateFilters: false,
+                maxCookTime: "",
+                maxCost: "10"
+            },
+            searchQuery: "test"
+        }
+
+        expect(processSettingsIntoParams(settings)).toEqual({
+            search: "test"
+        })
+    });
+})
+
+describe('browseRecipesReducer', () => {
+    test('correctly updates state on request fetching', () => {
+        const action = {
+            type: fetchBrowseRecipes.pending,
+            payload: {}
+        }
+
+        const previousState = {
+            status: "idle",
+            error: null,
+            data: "stale",
+        }
+
+        const expectedState = {
+            status: "fetching",
+            error: null,
+            data: previousState.data
+        }
+
+        expect(browseRecipesReducer(previousState, action)).toEqual(expectedState)
+    });
+
+    test('correctly updates state on response error', () => {
+        const action = {
+            type: fetchBrowseRecipes.rejected,
+            error: { message: "Error Message" }
+        }
+
+        const previousState = {
+            status: "fetching",
+            error: null,
+            data: "stale",
+        }
+
+        const expectedState = {
+            status: "idle",
+            error: "Error Message",
+            data: "stale"
+        }
+
+        expect(browseRecipesReducer(previousState, action)).toEqual(expectedState)
+    });
+
+    test('correctly updates state on response success', () => {
+        const action = {
+            type: fetchBrowseRecipes.fulfilled,
+            payload: { recipes: [], isRandom: false }
+        }
+
+        const previousState = {
+            status: "fetching",
+            error: null,
+            data: "stale"
+        }
+
+        const expectedState = {
+            status: "idle",
+            error: null,
+            data: { recipes: [], isRandom: false }
+        }
+
+        expect(browseRecipesReducer(previousState, action)).toEqual(expectedState)
+    });
+})

--- a/PlateUp-reactnative/redux/features/browse_recipes.test.js
+++ b/PlateUp-reactnative/redux/features/browse_recipes.test.js
@@ -7,7 +7,7 @@ describe('processSettingsIntoParams', () => {
         const settings = {
             filterSettings: {
                 activateFilters: true,
-                maxCookTime: "120",
+                maxCookTime: "150.5",
                 maxCost: ""
             },
             searchQuery: ""
@@ -15,7 +15,7 @@ describe('processSettingsIntoParams', () => {
 
         expect(processSettingsIntoParams(settings)).toEqual({
             maxCookTimeHour: "2",
-            maxCookTimeMinutes: "0",
+            maxCookTimeMinutes: "30",
             search: ""
         })
     });
@@ -88,7 +88,7 @@ describe('browseRecipesReducer', () => {
 
         const expectedState = {
             status: "idle",
-            error: "Error Message",
+            error: action.error.message,
             data: "stale"
         }
 

--- a/PlateUp-reactnative/redux/features/browse_recipes.test.js
+++ b/PlateUp-reactnative/redux/features/browse_recipes.test.js
@@ -25,13 +25,13 @@ describe('processSettingsIntoParams', () => {
             filterSettings: {
                 activateFilters: true,
                 maxCookTime: "",
-                maxCost: "10", // In dollars
+                maxCost: "10.50", // In dollars
             },
             searchQuery: "test"
         }
 
         expect(processSettingsIntoParams(settings)).toEqual({
-            maxCost: "1000", // In cents
+            maxCost: "1050", // In cents
             search: "test"
         })
     });

--- a/PlateUp-reactnative/redux/features/browse_recipes.test.js
+++ b/PlateUp-reactnative/redux/features/browse_recipes.test.js
@@ -89,7 +89,7 @@ describe('browseRecipesReducer', () => {
         const expectedState = {
             status: "idle",
             error: action.error.message,
-            data: "stale"
+            data: previousState.data
         }
 
         expect(browseRecipesReducer(previousState, action)).toEqual(expectedState)
@@ -110,7 +110,7 @@ describe('browseRecipesReducer', () => {
         const expectedState = {
             status: "idle",
             error: null,
-            data: { recipes: [], isRandom: false }
+            data: action.payload
         }
 
         expect(browseRecipesReducer(previousState, action)).toEqual(expectedState)


### PR DESCRIPTION
This PR tries to clean up the code in browseRecipes. I also add in some test coverage as this logic is important. The tests specifically ensure browseRecipesReducer functions as expected. I also unit test the logic in how we process our settings. We could add tests around the actions being dispatched. However, this is simple enough that we wouldn't get much out of testing the dispatching of actions, especially because we use redux toolkit to do that for us.