### PR TITLE
Fix iOS header issue where the search bar would persist

### DIFF
--- a/PlateUp-reactnative/navigation/Screens.js
+++ b/PlateUp-reactnative/navigation/Screens.js
@@ -29,7 +29,7 @@ const Drawer = createDrawerNavigator();
 
 function HomeStack() {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator headerMode="screen">
       <Stack.Screen
         name="Home"
         component={BrowseRecipes}
@@ -104,7 +104,7 @@ function HomeStack() {
 
 function GroceryInventoryStack() {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator headerMode="screen">
       <Stack.Screen
         name="GroceryInventory"
         component={GroceryInventory}
@@ -126,7 +126,7 @@ function GroceryInventoryStack() {
 
 function ShoppingListStack() {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator headerMode="screen">
       <Stack.Screen
         name="ShoppingList"
         component={ShoppingList}


### PR DESCRIPTION
On iOS, the search bar in the header would persist on every screen. This is a known iOS issue when the headerMode prop is not specified for the React Navigation Navigator.

More details on the issue: https://github.com/react-navigation/react-navigation/issues/6832?fbclid=IwAR3OphfBm9U8PpQmuPZn8AGh-QIGv0zNf99SJCJAp_9TxVTdsWj0-TQfvpk

@UTkzhang  verified its fine now with this fix.