### PR TITLE
AlertIOS was removed, use Alert instead

### DIFF
--- a/PlateUp-reactnative/constants/utils.js
+++ b/PlateUp-reactnative/constants/utils.js
@@ -1,5 +1,5 @@
 import {
-  AlertIOS, Dimensions, Platform, ToastAndroid
+  Alert, Dimensions, Platform, ToastAndroid
 } from 'react-native';
 
 const { height, width } = Dimensions.get('window');
@@ -9,7 +9,7 @@ export function toast(msg) {
   if (Platform.OS === 'android') {
     ToastAndroid.show(msg, ToastAndroid.LONG);
   } else {
-    AlertIOS.alert(msg);
+    Alert.prompt(msg);
   }
 }
 


### PR DESCRIPTION
This PR aims to solve some unexpected exceptions when using the application on iOS. The exceptions were caused by the AlertIOS function no longer being defined.