### PR TITLE
Recipe Step-By-Step update and other minor changes

### DIFF
--- a/PlateUp-reactnative/components/IngredientList.js
+++ b/PlateUp-reactnative/components/IngredientList.js
@@ -7,7 +7,7 @@ import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 
 import Icon from './Icon';
 import { argonTheme } from '../constants';
-import { toast, height } from '../constants/utils';
+import { toast } from '../constants/utils';
 
 const DEFAULT_DIALOG_STATE = {
   addItemDialogVisible: false,

--- a/PlateUp-reactnative/constants/utils.js
+++ b/PlateUp-reactnative/constants/utils.js
@@ -12,7 +12,7 @@ export function toast(msg) {
   if (Platform.OS === 'android') {
     ToastAndroid.show(msg, ToastAndroid.LONG);
   } else {
-    Alert.prompt(msg);
+    Alert.alert(msg);
   }
 }
 

--- a/PlateUp-reactnative/screens/RecipeStepByStep.js
+++ b/PlateUp-reactnative/screens/RecipeStepByStep.js
@@ -152,17 +152,30 @@ class RecipeStepByStep extends React.Component {
       imgs.push(ingredient.img);
     });
 
+    if (imgs.length === 0) {
+      return null;
+    }
+
     return (
-      imgs.map((image, index) => (
-        // Reasonable to disable here as this is a static array
-        // eslint-disable-next-line react/no-array-index-key
-        <Block key={index} style={{ marginBottom: 50 }}>
-          <Image
-            source={{ uri: image }}
-            style={{ width: '100%', height: '100%' }}
-          />
-        </Block>
-      ))
+      <Block style={styles.sliderContainer}>
+        <Swiper
+          activeDotColor={argonTheme.COLORS.PRIMARY}
+          autoplay
+          index={0}
+          key={imgs.length}
+        >
+          {imgs.map((image, index) => (
+            // Reasonable to disable here as this is a static array
+            // eslint-disable-next-line react/no-array-index-key
+            <Block key={index} style={{ marginBottom: 50 }}>
+              <Image
+                source={{ uri: image }}
+                style={{ width: '100%', height: '100%' }}
+              />
+            </Block>
+          ))}
+        </Swiper>
+      </Block>
     );
   }
 
@@ -191,17 +204,7 @@ class RecipeStepByStep extends React.Component {
         </Block>
 
         <Block style={styles.card}>
-          <Block style={styles.sliderContainer}>
-            <Swiper
-              activeDotColor={argonTheme.COLORS.PRIMARY}
-              autoplay
-              index={0}
-              key={stepDetails.equipment.length + stepDetails.ingredients.length}
-            >
-              {this.renderImages()}
-            </Swiper>
-          </Block>
-
+          {this.renderImages()}
           <ScrollView>
             <Text size={16}>
               {stepDetails.step_instruction}

--- a/PlateUp-reactnative/screens/Register.js
+++ b/PlateUp-reactnative/screens/Register.js
@@ -1,9 +1,8 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import { Block, Checkbox, Text } from 'galio-framework';
+import { Block, Text } from 'galio-framework';
 import React from 'react';
 import {
   ActivityIndicator,
-  Dimensions,
   Image,
   Keyboard,
   KeyboardAvoidingView,

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Plate Up
 
-This repository contains the source code for Group 5 - Pyromanaic's variant of Chef's Co-Pilot. This application allows users to browse new recipes and be provided with the necessary information to be able to recreate these recipes.
+This repository contains the source code for Group 5 - Pyromaniacs' variant of Chef's Co-Pilot. This application allows users to browse new recipes and be provided with the necessary information to be able to recreate these recipes.
 
-The application follows a client-server model. The client is written in React Native as a mobile application and the server is written as a Python Flask web application.
+The application follows a client-server model. The client is written in React Native as a mobile application and is found in `./PlateUp-reactnative`. The server is written as a Python Flask web application. The Python Flask web application is separated as a GitHub submodule found in `./PlateUp-flask`.
 
 ## Distribution
 
-The client application is distributed through Expo and is availiable as a mobile application at: https://expo.io/@pyromaniacs/projects/plate-up-uoft-ece444. The server powering the client is availiable at https://sheltered-thicket-73220.herokuapp.com/. See PlateUp-flask submodule for more details on the server application.
+The client application is distributed through Expo and is availiable as a mobile application at https://expo.io/@pyromaniacs/projects/plate-up-uoft-ece444. The server powering the client is availiable at https://sheltered-thicket-73220.herokuapp.com/. See PlateUp-flask submodule for more details on the server application.
 
 ## Application Features
 
-This section allows the current features implemented for the application.
+This section outlines the current features implemented for the application.
 
 ### Account Management
 


### PR DESCRIPTION
This PR fixes a small UI bug on the Recipe Step-By-Step page. Previously if there were no images for a given step, the images container would still take up space. The intended behavior is for the image container to not be rendered at all.

Other changes:
- Fix linting errors that slipped through
- README.md updates

Screenshots:
![image](https://user-images.githubusercontent.com/42985270/99137425-bee92680-25f8-11eb-93f0-54b33c3d699a.png)
